### PR TITLE
removed TracingConfig from Lambda definition

### DIFF
--- a/VPC/route-table-update-post-EC2-builds.json
+++ b/VPC/route-table-update-post-EC2-builds.json
@@ -267,10 +267,7 @@
                 ]]}
                 },
             "Runtime": "python2.7",
-            "Timeout": 20,
-            "TracingConfig": {
-                "Mode": "Active"
-            }
+            "Timeout": 20
         }
     }
     }


### PR DESCRIPTION
by removing "TracingMode" the Lambda function's IAM role will not require write permissions to AWS XRAY.

Successfully tested.

This is done to close issue #16 