### PR TITLE
device1 go Standby

### DIFF
--- a/BIG-IP/template.json
+++ b/BIG-IP/template.json
@@ -701,8 +701,8 @@
       "Metadata": {
        "AWS::CloudFormation::Init": {
         "configSets" : {
-            "SCCA" : [ "config", "bigipstig", "dodCerts", "AS3-baseline-routing" ],
-            "standard": [ "config", "AS3-baseline-routing" ]
+            "SCCA" : [ "config", "bigipstig", "dodCerts", "goStandby", "AS3-baseline-routing" ],
+            "standard": [ "config", "goStandby", "AS3-baseline-routing" ]
           },
         "config": {
          "commands": {
@@ -1365,6 +1365,52 @@
                                 ] 
                                 ] 
                         },
+                    "group": "root",
+                    "mode": "000755",
+                    "owner": "root"
+                }
+            }
+        },
+        "goStandby": {
+            "commands": {
+                "010-goStandby": { 
+                    "test" : "[ -f /config/goStandby.sh ]",
+                    "command": { 
+                       "Fn::Join": [  
+                        " ", 
+                        [ 
+                         "nohup /config/waitThenRun.sh",
+                         "f5-rest-node /config/cloud/aws/node_modules/@f5devcentral/f5-cloud-libs/scripts/runScript.js",
+                         "--file /config/goStandby.sh",
+                         "--output /var/log/goStandby.log",
+                         "--log-level silly",
+                         {
+                            "Fn::If":
+                               [
+                                   "SCCA",
+                                   "--wait-for CERTS_DONE",
+                                   "--wait-for PASSWORD_REMOVED"
+                               ]
+                        },
+                         "--signal GO_STANDBY",
+                         "&>> /var/log/cloud/aws/install.log < /dev/null &"
+                        ] 
+                       ] 
+                  }, 
+                  "cwd" : "/config"  
+                  }
+            },
+            "files": {
+                "/config/goStandby.sh": {
+                    "content": {
+                        "Fn::Join": [
+                                "", 
+                                [ 
+                                    "#!/bin/bash\n",
+                                    "tmsh run /sys failover standby"
+                                ] 
+                        ] 
+                    },
                     "group": "root",
                     "mode": "000755",
                     "owner": "root"


### PR DESCRIPTION
- This was tested successfully.
- Logs show that the script was run to "tmsh run /sys failover standby" on Device1 of both tiers
- this fixes issue #2 