### PR TITLE
Work moleary remove EIPs from internal tier

### DIFF
--- a/BIG-IP/atc/as3/install-rpm.sh
+++ b/BIG-IP/atc/as3/install-rpm.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Target machine is required for installation."
+    exit 0
+fi
+
+if [ -z "$2" ]; then
+    echo "Credentials [username:password] for target machine are required for installation."
+    exit 0
+fi
+
+if [ -z "$3" ]; then
+    echo "File path to RPM is required for installation."
+    exit 0
+fi
+
+TARGET="$1"
+CREDS="$2"
+TARGET_RPM="$3"
+RPM_NAME=$(basename $TARGET_RPM)
+CURL_FLAGS="--silent --write-out \n --insecure -u $CREDS"
+
+poll_task () {
+    STATUS="STARTED"
+    while [ $STATUS != "FINISHED" ]; do
+        sleep 1
+        RESULT=$(curl ${CURL_FLAGS} "https://$TARGET/mgmt/shared/iapp/package-management-tasks/$1")
+        STATUS=$(echo $RESULT | jq -r .status)
+        if [ $STATUS = "FAILED" ]; then
+            echo "Failed to" $(echo $RESULT | jq -r .operation) "package:" \
+                $(echo $RESULT | jq -r .errorMessage)
+            exit 1
+        fi
+    done
+}
+
+#Get list of existing f5-appsvcs packages on target
+TASK=$(curl $CURL_FLAGS -H "Content-Type: application/json" \
+    -X POST https://$TARGET/mgmt/shared/iapp/package-management-tasks -d "{operation: 'QUERY'}")
+poll_task $(echo $TASK | jq -r .id)
+AS3RPMS=$(echo $RESULT | jq -r '.queryResponse[].packageName | select(. | startswith("f5-appsvcs"))')
+
+#Uninstall existing f5-appsvcs packages on target
+for PKG in $AS3RPMS; do
+    echo "Uninstalling $PKG on $TARGET"
+    DATA="{\"operation\":\"UNINSTALL\",\"packageName\":\"$PKG\"}"
+    TASK=$(curl ${CURL_FLAGS} "https://$TARGET/mgmt/shared/iapp/package-management-tasks" \
+        --data $DATA -H "Origin: https://$TARGET" -H "Content-Type: application/json;charset=UTF-8")
+    poll_task $(echo $TASK | jq -r .id)
+done
+
+#Upload new f5-appsvcs RPM to target
+echo "Uploading RPM to https://$TARGET/mgmt/shared/file-transfer/uploads/$RPM_NAME"
+LEN=$(wc -c $TARGET_RPM | awk 'NR==1{print $1}')
+RANGE_SIZE=5000000
+CHUNKS=$(( $LEN / $RANGE_SIZE))
+for i in $(seq 0 $CHUNKS); do
+    START=$(( $i * $RANGE_SIZE))
+    END=$(( $START + $RANGE_SIZE))
+    END=$(( $LEN < $END ? $LEN : $END))
+    OFFSET=$(( $START + 1))
+    curl ${CURL_FLAGS} -o /dev/null --write-out "" \
+        https://$TARGET/mgmt/shared/file-transfer/uploads/$RPM_NAME \
+        --data-binary @<(tail -c +$OFFSET $TARGET_RPM) \
+        -H "Content-Type: application/octet-stream" \
+        -H "Content-Range: $START-$(( $END - 1))/$LEN" \
+        -H "Content-Length: $(( $END - $START ))" \
+        -H "Connection: keep-alive"
+done
+
+#Install f5-appsvcs on target
+echo "Installing $RPM_NAME on $TARGET"
+DATA="{\"operation\":\"INSTALL\",\"packageFilePath\":\"/var/config/rest/downloads/$RPM_NAME\"}"
+TASK=$(curl ${CURL_FLAGS} "https://$TARGET/mgmt/shared/iapp/package-management-tasks" \
+    --data $DATA -H "Origin: https://$TARGET" -H "Content-Type: application/json;charset=UTF-8")
+poll_task $(echo $TASK | jq -r .id)
+
+echo "Waiting for /info endpoint to be available"
+until curl ${CURL_FLAGS} -o /dev/null --write-out "" --fail --silent \
+    "https://$TARGET/mgmt/shared/appsvcs/info"; do
+    sleep 1
+done
+
+echo "Installed $RPM_NAME on $TARGET"
+
+exit 0

--- a/BIG-IP/atc/as3/tier1/demoAppVIP-ExternalTier.json
+++ b/BIG-IP/atc/as3/tier1/demoAppVIP-ExternalTier.json
@@ -1,0 +1,56 @@
+{
+    "class": "AS3",
+    "action": "deploy",
+    "persist": true,
+    "declaration": {
+        "class": "ADC",
+        "schemaVersion": "3.5.0",
+        "id": "urn:uuid:b92236ad-a677-4574-8bce-7d1487aeb62f",
+        "label": "demoApp",
+        "remark": "demoApp",
+        "demoApp": {
+            "class": "Tenant",
+            "demoApp": {
+                "class": "Application",
+                "template": "generic",
+                "demoApp_vs": {
+                    "class": "Service_TCP",
+                    "virtualAddresses": [
+						"10.0.0.50"
+                    ],
+                    "virtualPort": 443,
+                    "pool": "demoApp_pool",
+                    "serverTLS": {
+                        "bigip": "/Common/clientssl"
+                    }
+                },
+                "demoApp_vs_redirect": {
+                    "class": "Service_HTTP",
+                    "template": "http",
+                    "virtualAddresses": [
+						"10.0.0.50"
+                    ],
+                    "virtualPort": 80,
+                    "iRules": [
+                        {"bigip": "/Common/_sys_https_redirect"}
+                    ],
+                    "profileHTTP": {"bigip": "/Common/http" }
+                },
+                "demoApp_pool": {
+                    "class": "Pool",
+                    "monitors": [
+                        "tcp"
+                    ],
+				    "members": [
+                        {
+                            "servicePort": 80,
+                            "serverAddresses": [
+                                "10.0.2.50"
+                            ]
+                        }
+					]
+                }
+            }
+		}
+    }
+}

--- a/BIG-IP/atc/as3/tier3/demoAppVIP-InternalTier.json
+++ b/BIG-IP/atc/as3/tier3/demoAppVIP-InternalTier.json
@@ -1,0 +1,44 @@
+{
+    "class": "AS3",
+    "action": "deploy",
+    "persist": true,
+    "declaration": {
+        "class": "ADC",
+        "schemaVersion": "3.5.0",
+        "id": "urn:uuid:b92236ad-a677-4574-8bce-7d1487aeb62f",
+        "label": "demoApp",
+        "remark": "demoApp",
+        "demoApp": {
+            "class": "Tenant",
+            "demoApp": {
+                "class": "Application",
+                "template": "generic",
+                "demoApp_vs": {
+                    "class": "Service_TCP",
+                    "virtualAddresses": [
+						"10.0.2.50"
+                    ],
+                    "virtualPort": 80,
+                    "pool": "demoApp_pool",
+                    "clientTLS": {
+                        "bigip": "/Common/serverssl"
+                    }
+                },
+                "demoApp_pool": {
+                    "class": "Pool",
+                    "monitors": [
+                        "tcp"
+                    ],
+				    "members": [
+                        {
+                            "servicePort": 443,
+                            "serverAddresses": [
+                                "10.1.0.50"
+                            ]
+                        }
+					]
+                }
+            }
+		}
+    }
+}

--- a/BIG-IP/template.json
+++ b/BIG-IP/template.json
@@ -143,6 +143,8 @@
          "pVpcStackName",
          "pTier",
          "internalRoutesGWIP",
+         "demoAppVIP",
+         "demoAppPoolMember",
          "numberOfAdditionalNics",
          "additionalNicLocation"
         ]
@@ -194,7 +196,8 @@
         },
         "Parameters": [
          "declarationUrl",
-         "declarationUrlrouting"
+         "declarationUrlrouting",
+         "declarationUrldemoApp"
         ]
        }
       ],
@@ -207,6 +210,12 @@
         },
         "internalRoutesGWIP": {
          "default": "GW IP address for routes to point via Internal interface."
+        },
+        "demoAppVIP": {
+         "default": "Virtual Address for VIP"
+        },
+        "demoAppPoolMember": {
+         "default": "Pool member for app"
         },
        "pBaselineCompliance": {
         "default": "Choose your baseline compliance posture"
@@ -229,7 +238,6 @@
        "customImageId": {
         "default": "Custom Image Id"
        },
-
        "environment": {
         "default": "Environment"
        },
@@ -561,6 +569,18 @@
         "Type": "String",
         "Default": "10.0.3.1"
        },
+       "demoAppVIP": {
+        "Type": "String",
+        "Default": "10.0.2.50"
+       },
+       "extSelfIP": {
+        "Type": "String",
+        "Default": "10.0.2.10"
+       },
+       "demoAppPoolMember": {
+        "Type": "String",
+        "Default": "10.1.0.50"
+       },
      "pBaselineCompliance": {
       "AllowedValues" : ["Enterprise", "SCCA"],
       "ConstraintDescription": "Choose your baseline compliance posture",
@@ -608,6 +628,12 @@
       "Description": "URL for the AS3 declaration JSON file to be deployed. Leave as **none** to deploy without a service configuration.",
       "Type": "String"
      },
+     "declarationUrldemoApp": {
+        "AllowedPattern": "^(http:\\/\\/|https:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?$|^none$",
+        "Default": "none",
+        "Description": "URL for the AS3 declaration JSON file to be deployed. Leave as **none** to deploy without a service configuration.",
+        "Type": "String"
+       },
      "environment": {
       "Default": "f5env",
       "Description": "Name of the Environment Tag",
@@ -716,15 +742,27 @@
       "Default": "UTC",
       "Description": "Olson timezone string. Acceptable values can be found from /usr/share/zoneinfo directory located on BIG-IP. Also, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones referencing the TZ* column for Olsen timezone examples.",
       "Type": "String"
-     }
+     },
+     "as3rpmUrl": {
+        "AllowedPattern": "^(http:\\/\\/|https:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?$|^none$",
+        "Default": "none",
+        "Description": "URL to download desired version of AS3 rpm",
+        "Type": "String"
+       },
+     "as3InstallFileUrl": {
+       "AllowedPattern": "^(http:\\/\\/|https:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?$|^none$",
+       "Default": "none",
+       "Description": "URL to download installation script for AS3",
+       "Type": "String"
+       } 
     },
     "Resources": {
      "Bigip1Instance": { 
       "Metadata": {
        "AWS::CloudFormation::Init": {
         "configSets" : {
-            "SCCA" : [ "config", "bigipstig", "dodCerts", "AS3-baseline-routing", "mgmt-baseline", "app1-baseline" ],
-            "Enterprise": [ "config", "AS3-baseline-routing", "mgmt-baseline" ]
+            "SCCA" : [ "config", "upgrade-AS3", "bigipstig", "dodCerts", "AS3-baseline-routing", "mgmt-baseline", "app1-baseline"],
+            "Enterprise": [ "config", "upgrade-AS3", "AS3-baseline-routing", "mgmt-baseline", "app1-baseline"]
           },
         "config": {
          "commands": {
@@ -1350,6 +1388,44 @@
           }
          }
         },
+        "upgrade-AS3": {
+            "commands": {
+                "010-update-as3-version": {
+                    "test" : "[ -f /config/cloud/f5-appsvcs-3.13.2-1.noarch.rpm -a -f /config/cloud/install-rpm.sh ]",
+                    "command": {
+                        "Fn::Join": [
+                            " ",
+                            [
+                             "nohup /config/waitThenRun.sh",
+                             "f5-rest-node /config/cloud/aws/node_modules/@f5devcentral/f5-cloud-libs/scripts/runScript.js",
+                             "--file /config/cloud/install-rpm.sh",
+                             "--cl-args '127.0.0.1 admin:password /config/cloud/f5-appsvcs-3.13.2-1.noarch.rpm'",
+                             "--output /var/log/install-rpm.log",
+                             "--log-level silly",
+                             "--wait-for CLUSTER_DONE",
+                             "--signal AS3UPGRADE_DONE",
+                             "&>> /var/log/cloud/aws/install.log < /dev/null &"
+                            ]
+                           ]
+                    },
+                    "cwd" : "/config/cloud"
+                  }
+            },
+            "files": {
+                "/config/cloud/f5-appsvcs-3.13.2-1.noarch.rpm": {
+                    "group": "root",
+                    "mode": "000755",
+                    "owner": "root",
+                    "source": {"Ref": "as3rpmUrl"}
+                   },
+                "/config/cloud/install-rpm.sh": {
+                    "group": "root",
+                    "mode": "000755",
+                    "owner": "root",
+                    "source": {"Ref": "as3InstallFileUrl"}
+                   }
+            }
+        },
         "bigipstig": {
             "commands": {
                 "081-apply-stigs": {
@@ -1363,7 +1439,7 @@
                              "--file /config/bigipstig.sh",
                              "--output /var/log/bigipstig.log",
                              "--log-level silly",
-                             "--wait-for CLUSTER_DONE",
+                             "--wait-for AS3UPGRADE_DONE",
                              "--signal BIGIPSTIG_DONE",
                              "&>> /var/log/cloud/aws/install.log < /dev/null &"
                             ]
@@ -1429,80 +1505,8 @@
                 }
             }
         },
-        "goStandby": {
-            "commands": {
-                "010-goStandby": { 
-                    "test" : "[ -f /config/goStandby.sh ]",
-                    "command": { 
-                       "Fn::Join": [  
-                        " ", 
-                        [ 
-                         "nohup /config/waitThenRun.sh",
-                         "f5-rest-node /config/cloud/aws/node_modules/@f5devcentral/f5-cloud-libs/scripts/runScript.js",
-                         "--file /config/goStandby.sh",
-                         "--output /var/log/goStandby.log",
-                         "--log-level silly",
-                         {
-                            "Fn::If":
-                               [
-                                   "SCCA",
-                                   "--wait-for CERTS_DONE",
-                                   "--wait-for PASSWORD_REMOVED"
-                               ]
-                        },
-                         "--signal GO_STANDBY",
-                         "&>> /var/log/cloud/aws/install.log < /dev/null &"
-                        ] 
-                       ] 
-                  }, 
-                  "cwd" : "/config"  
-                  }
-            },
-            "files": {
-                "/config/goStandby.sh": {
-                    "content": {
-                        "Fn::Join": [
-                                "", 
-                                [ 
-                                    "#!/bin/bash\n",
-                                    "tmsh run /sys failover standby"
-                                ] 
-                        ] 
-                    },
-                    "group": "root",
-                    "mode": "000755",
-                    "owner": "root"
-                }
-            }
-        },
         "AS3-baseline-routing": {
             "commands": {
-                "010-apply-device-routes": { 
-                    "test" : "[ -f /config/deployDeviceRoutes.sh ]",
-                    "command": { 
-                       "Fn::Join": [  
-                        " ", 
-                        [ 
-                         "nohup /config/waitThenRun.sh",
-                         "f5-rest-node /config/cloud/aws/node_modules/@f5devcentral/f5-cloud-libs/scripts/runScript.js",
-                         "--file /config/deployDeviceRoutes.sh",
-                         "--output /var/log/deployDeviceRoutes.log",
-                         "--log-level silly",
-                         {
-                            "Fn::If":
-                               [
-                                   "SCCA",
-                                   "--wait-for CERTS_DONE",
-                                   "--wait-for PASSWORD_REMOVED"
-                               ]
-                        },
-                         "--signal DEVICE_ROUTES_DONE",
-                         "&>> /var/log/cloud/aws/install.log < /dev/null &"
-                        ] 
-                       ] 
-                  }, 
-                  "cwd" : "/config"  
-                  }, 
                 "083-apply-AS3-baseline-routing": { 
                     "test" : "[ -f /config/deployBaselineRouting.sh ]",
                     "command": { 
@@ -1514,42 +1518,23 @@
                          "--file /config/deployBaselineRouting.sh",
                          "--output /var/log/deployBaselineRouting.log",
                          "--log-level silly",
-                         "--wait-for DEVICE_ROUTES_DONE",
+                         {
+                            "Fn::If":
+                               [
+                                   "SCCA",
+                                   "--wait-for CERTS_DONE",
+                                   "--wait-for AS3UPGRADE_DONE"
+                               ]
+                        },
                          "--signal AS3_ROUTING_DONE",
                          "&>> /var/log/cloud/aws/install.log < /dev/null &"
                         ] 
                        ] 
                   }, 
                   "cwd" : "/config"  
-                  } 
-                  
+                  }    
             },
             "files": {
-                "/config/deployDeviceRoutes.sh": {
-                    "group": "root",
-                    "mode": "000755",
-                    "owner": "root",
-                    "content": {
-                        "Fn::Join": [
-                            "",
-                            [
-                            "#!/bin/bash\n",
-                            "gw='",
-                            {
-                                "Ref": "internalRoutesGWIP"
-                            },
-                            "'\n",
-                            "\n",
-                            "echo  -e 'create cli transaction;\n",
-                            "create net route 10.0.0.0/8 gw '${gw}'\n",
-                            "create net route 172.16.0.0/12 gw '${gw}'\n",
-                            "create net route 192.168.0.0/16 gw '${gw}'\n",
-                            "save /sys config\n",
-                            "submit cli transaction' | tmsh -q\n"
-                            ]
-                        ]
-                    }
-                },
                 "/config/deployBaselineRouting.sh": {
                     "group": "root",
                     "mode": "000755",
@@ -1655,15 +1640,17 @@
                           ]
                           },
                           "'\n",
+                          "internalRoutesGWIP='",
+                          {
+                              "Ref": "internalRoutesGWIP"
+                          },
+                          "'\n",
                           "\n",
                           "# internal gateway\n",
                           "network=$(/sbin/ifconfig internal | grep 'inet' | cut -d: -f2 | awk '{print $2}' | cut -d\".\" -f1-3)\n",
                           "gw=\"$network\"\".1\"\n",
                           "\n",
                           "### FILE CREATION FOR MGMT ACCESS\n",
-                          "echo  -e 'create cli transaction;\n",
-                          "create auth partition '${partition}' { };\n",
-                          "submit cli transaction' | tmsh -q\n",
                           "\n",
                           "echo  -e 'create cli transaction;\n",
                           "cd /'${partition}';\n",
@@ -1676,6 +1663,11 @@
                           "modify security ip-intelligence global-policy ip-intelligence-policy ip-intelligence;\n",
                           "submit cli transaction' | tmsh -q\n",
                           "\n",
+                          "echo  -e 'create cli transaction;\n",
+                          "create net route 10.0.0.0/8 gw '${internalRoutesGWIP}'\n",
+                          "create net route 172.16.0.0/12 gw '${internalRoutesGWIP}'\n",
+                          "create net route 192.168.0.0/16 gw '${internalRoutesGWIP}'\n",
+                          "submit cli transaction' | tmsh -q\n",
                           "### END DEPLOYMENT OF FILE CREATION FOR MGMT ACCESS"
                           ]
                       ]
@@ -1731,11 +1723,109 @@
                         "delete auth partition '${partition}'\n",
                         "submit cli transaction' | tmsh -q\n",
                         "\n",
+                        "echo  -e 'create cli transaction;\n",
+                        "delete net route 10.0.0.0/8\n",
+                        "delete net route 172.16.0.0/12\n",
+                        "delete net route 192.168.0.0/16\n",
+                        "submit cli transaction' | tmsh -q\n",
                         "### END DEPLOYMENT OF OBJECT REMOVAL FOR MGMT ACCESS"
                         ]
                     ]
                 }
             }
+            }
+          },
+          "demoApp": {
+            "commands": {
+                "010-deployDemoApp": { 
+                    "test" : "[ -f /config/deployDemoApp.sh ]",
+                    "command": { 
+                        "Fn::Join": [  
+                        " ", 
+                        [ 
+                            "nohup /config/waitThenRun.sh",
+                            "f5-rest-node /config/cloud/aws/node_modules/@f5devcentral/f5-cloud-libs/scripts/runScript.js",
+                            "--file /config/deployDemoApp.sh",
+                            "--output /var/log/deployDemoApp.log",
+                            "--log-level silly",
+                            "--wait-for MGMT_DONE",
+                            "--signal DEMOAPP_DONE",
+                            "&>> /var/log/cloud/aws/install.log < /dev/null &"
+                        ] 
+                        ] 
+                    }, 
+                    "cwd" : "/config"  
+                    }    
+                },
+            "files": {
+                "/config/deployDemoApp.sh": {
+                    "group": "root",
+                    "mode": "000755",
+                    "owner": "root",
+                    "content": {
+                        "Fn::Join": [
+                            "",
+                            [
+                            "#!/bin/bash\n",
+                            "declarationUrldemoApp='",
+                            {"Ref": "declarationUrldemoApp"},
+                            "'\n",
+                            "vip='",
+                            {"Ref": "demoAppVIP"},
+                            "'\n",
+                            "poolmember='",
+                            {"Ref": "demoAppPoolMember"},
+                            "'\n",
+                            "virtualport='",
+                            {"Fn::If": [
+                                "Tier1",
+                                "443'\n",
+                                "80'"
+                            ]
+                            },
+                            "\n",
+                            "serviceport='",
+                             {"Fn::If": [
+                                "Tier1",
+                                "80'\n",
+                                "443'"
+                            ]
+                            },
+                            "\n",
+                            "### START DEPLOYMENT OF AS3 DECLARATION FOR MGMT ACCESS\n",
+                            "source /config/cloud/aws/onboard_config_vars\n",
+                            "deployed=\"no\"\n",
+                            "url_regex=\"(http:\\/\\/|https:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?$\"\n",
+                            "file_loc=\"/config/cloud/demoApp.json\"\n",
+                            "if [[ $declarationUrldemoApp =~ $url_regex ]]; then\n",
+                            "  response_code=$(/usr/bin/curl -sk -w \"%{http_code}\" $declarationUrldemoApp -o $file_loc)\n",
+                            "  if [[ $response_code == 200 ]]; then\n",
+                            "    echo \"AS3 download complete; checking for valid JSON.\"\n",
+                            "    cat $file_loc | jq .class\n",
+                            "    if [[ $? == 0 ]]; then\n",
+                            "      tmp=$(mktemp)\n",
+                            "      cat $file_loc | jq -r --arg vip $vip --arg poolmember $poolmember --argjson virtualport $virtualport --argjson serviceport $serviceport '.declaration.demoApp.demoApp.demoApp_vs.virtualAddresses[] |= $vip | .declaration.demoApp.demoApp.demoApp_vs.virtualPort |= $virtualport  | .declaration.demoApp.demoApp.demoApp_pool.members[] |= {\"servicePort\": $serviceport, \"serverAddresses\": [$poolmember]}' > \"$tmp\" && mv $tmp $file_loc\n",
+                            "      response_code=$(/usr/bin/curl -skvvu ${adminUsername}:XXX -w \"%{http_code}\" -X POST -H \"Content-Type: application/json\" https://localhost:${managementGuiPort}/mgmt/shared/appsvcs/declare -d @$file_loc -o /dev/null)\n",
+                            "      if [[ $response_code == 200 || $response_code == 502 ]]; then\n",
+                            "        echo \"Deployment of custom application succeeded.\"\n",
+                            "        deployed=\"yes\"\n",
+                            "      else\n",
+                            "         echo \"Failed to deploy AS3 declaration; continuing...\"\n",
+                            "      fi\n",
+                            "    else\n",
+                            "      echo \"Custom config was not valid JSON, continuing...\"\n",
+                            "    fi\n",
+                            "  else\n",
+                            "    echo \"Failed to download custom config; continuing...\"\n",
+                            "  fi\n",
+                            "else\n",
+                            "  echo \"Custom config was not a URL, continuing...\"\n",
+                            "fi\n",
+                            "### END DEPLOYMENT OF AS3 DECLARATION FOR MGMT ACCESS"
+                            ]
+                        ]
+                    }
+                }    
             }
           },
           "app1-baseline": {
@@ -1789,7 +1879,7 @@
                         "virtualAddress='",
                         {
                             "Fn::Select": [
-                                "1",
+                                "0",
                                 {
                                     "Fn::GetAtt": [
                                     "Bigip1subnet1Az1Interface",
@@ -1809,7 +1899,7 @@
                         "'\n",
                         "node1='",
                         {
-                        "Ref": "pVirtualPrivateIP"
+                        "Ref": "demoAppPoolMember"
                         },
                         "'\n",
                         "\n",
@@ -1836,9 +1926,9 @@
                         "echo  -e 'create cli transaction;\n",
                         "cd /'${partition}';\n",
                         "create ltm node /'${partition}'/'${node1}' { address '${node1}' };\n",
+                        "create ltm pool /'${partition}'/'${appName}'_http_pool {  members add { '${node1}':http { address '${node1}' session user-enabled state user-up } }  min-active-members 1 monitor min 1 of { /Common/http } };\n",                        
                         "create ltm virtual /'${partition}'/'${appName}'_http { description '${appName}'_http destination /'${partition}'/'${virtualAddress}':http ip-protocol tcp mask 255.255.255.255 persist none profiles replace-all-with { /Common/f5-tcp-progressive {} http } rules { /Common/_sys_https_redirect } source 0.0.0.0/0 source-address-translation { type automap } translate-address enabled translate-port enabled };\n",
-                        "create ltm pool /'${partition}'/'${appName}'_https_pool { members none min-active-members 1 monitor min 1 of { /Common/https } };\n",
-                        "create ltm virtual /'${partition}'/'${appName}'_https {  description '${appName}'_https destination /'${partition}'/'${virtualAddress}':https ip-protocol tcp mask 255.255.255.255 pool /'${partition}'/'${appName}'_https_pool profiles replace-all-with { /Common/f5-tcp-progressive { } http } source 0.0.0.0/0 source-address-translation { type automap } translate-address enabled translate-port enabled };\n",
+                        "create ltm virtual /'${partition}'/'${appName}'_https {  description '${appName}'_https destination /'${partition}'/'${virtualAddress}':https ip-protocol tcp mask 255.255.255.255 pool /'${partition}'/'${appName}'_http_pool profiles replace-all-with { /Common/clientssl /Common/f5-tcp-progressive { } http } source 0.0.0.0/0 source-address-translation { type automap } translate-address enabled translate-port enabled };\n",
                         "submit cli transaction' | tmsh -q\n",
                         "\n",
                         "# add afm and logging\n",
@@ -1848,13 +1938,13 @@
                         "submit cli transaction' | tmsh -q\n",
                         "\n",
                         "#service Discovery pool\n",
-                        "echo  -e 'create cli transaction;\n",
-                        "create sys application service /'${partition}'/'${appName}' template f5.service_discovery device-group same_az_failover_group traffic-group traffic-group-1 strict-updates disabled variables replace-all-with { basic__advanced { value no } basic__display_help { value hide } cloud__aws_bigip_in_ec2 { value yes } cloud__aws_region { value ",
+                        "#echo  -e 'create cli transaction;\n",
+                        "#create sys application service /'${partition}'/'${appName}' template f5.service_discovery device-group same_az_failover_group traffic-group traffic-group-1 strict-updates disabled variables replace-all-with { basic__advanced { value no } basic__display_help { value hide } cloud__aws_bigip_in_ec2 { value yes } cloud__aws_region { value ",
                         {
                             "Ref": "AWS::Region"
                         },
                         " } cloud__aws_use_role { value no } cloud__cloud_provider { value aws } monitor__frequency { value 30 } monitor__http_method { value GET } monitor__http_version { value http11 } monitor__monitor { value \"/#create_new#\" } monitor__response { value 200 } monitor__type { value https } monitor__uri { value / } pool__interval { value 10 } pool__member_conn_limit { value 0 } pool__member_port { value 443 } pool__pool_to_use { value \"/'${partition}'/'${appName}'_https_pool\" } pool__public_private { value private } pool__tag_key { value '${tagKey}' } pool__tag_value { value '${tagValue}' } };\n",
-                        "submit cli transaction' | tmsh -q\n",
+                        "#submit cli transaction' | tmsh -q\n",
                         "\n",
                         "# save config\n",
                         "echo  -e 'create cli transaction;\n",
@@ -1872,13 +1962,13 @@
                             "\n",
                             "appName=\"app1\"\n",
                             "# tag\n",
-                            "tagKey=\"APPNAME\"\n", 
-                            "tagValue=\"LINUXSERVER\"\n",
+                            "tagKey=\"Application\"\n", 
+                            "tagValue=\"demoApp\"\n",
                             "\n",
                             "virtualAddress='",
                             {
                                 "Fn::Select": [
-                                    "1",
+                                    "0",
                                     {
                                         "Fn::GetAtt": [
                                         "Bigip1subnet1Az1Interface",
@@ -1932,8 +2022,8 @@
                             "echo  -e 'create cli transaction;\n",
                             "cd /'${partition}';\n",
                             "create ltm node /'${partition}'/'${node1}' { address '${node1}' };\n",
-                            "create ltm virtual /'${partition}'/'${appName}'_http { description '${appName}'_http destination /'${partition}'/'${virtualAddress}':http ip-protocol tcp mask 255.255.255.255 persist none profiles replace-all-with { /Common/f5-tcp-progressive {} http } rules { /Common/_sys_https_redirect } source 0.0.0.0/0 source-address-translation { type automap } translate-address enabled translate-port enabled };\n",
                             "create ltm pool /'${partition}'/'${appName}'_https_pool { members none min-active-members 1 monitor min 1 of { /Common/https } };\n",
+                            "create ltm virtual /'${partition}'/'${appName}'_http { description '${appName}'_http destination /'${partition}'/'${virtualAddress}':http ip-protocol tcp mask 255.255.255.255 persist none profiles replace-all-with { /Common/serverssl /Common/f5-tcp-progressive {} http } pool /'${partition}'/'${appName}'_https_pool source 0.0.0.0/0 source-address-translation { type automap } translate-address enabled translate-port enabled };\n",
                             "create ltm virtual /'${partition}'/'${appName}'_https {  description '${appName}'_https destination /'${partition}'/'${virtualAddress}':https ip-protocol tcp mask 255.255.255.255 persist replace-all-with { /Common/cookie { default yes } } pool /'${partition}'/'${appName}'_https_pool security-log-profiles add { \"Log all requests\" } profiles replace-all-with { /Common/f5-tcp-progressive { } http websecurity } source 0.0.0.0/0 source-address-translation { type automap } translate-address enabled translate-port enabled };\n",
                             "submit cli transaction' | tmsh -q\n",
                             "\n",
@@ -2207,7 +2297,16 @@
          "Ref": "bigipExternalSecurityGroup"
         }
        ],
-       "SecondaryPrivateIpAddressCount": "2",
+       "PrivateIpAddresses": [
+        {
+            "Primary" : true,
+            "PrivateIpAddress" : {"Ref": "extSelfIP"}
+          },
+          {
+            "Primary" : false,
+            "PrivateIpAddress" : {"Ref": "demoAppVIP"}
+          }
+       ],
        "SourceDestCheck": false,
        "SubnetId": {
         "Fn::If" : [
@@ -2273,8 +2372,8 @@
       "Metadata": {
        "AWS::CloudFormation::Init": {
         "configSets" : {
-            "SCCA" : [ "config", "bigipstig", "signal-complete" ],
-            "Enterprise": [ "config", "signal-complete" ]
+            "SCCA" : [ "config", "upgrade-AS3", "bigipstig", "signal-complete" ],
+            "Enterprise": [ "config", "upgrade-AS3", "signal-complete" ]
           },
         "config": {
          "commands": {
@@ -2845,6 +2944,44 @@
           }
          }
         },
+        "upgrade-AS3": {
+            "commands": {
+                "010-update-as3-version": {
+                    "test" : "[ -f /config/cloud/f5-appsvcs-3.13.2-1.noarch.rpm -a -f /config/cloud/install-rpm.sh ]",
+                    "command": {
+                        "Fn::Join": [
+                            " ",
+                            [
+                             "nohup /config/waitThenRun.sh",
+                             "f5-rest-node /config/cloud/aws/node_modules/@f5devcentral/f5-cloud-libs/scripts/runScript.js",
+                             "--file /config/cloud/install-rpm.sh",
+                             "--cl-args '127.0.0.1 admin:password /config/cloud/f5-appsvcs-3.13.2-1.noarch.rpm'",
+                             "--output /var/log/install-rpm.log",
+                             "--log-level silly",
+                             "--wait-for CLUSTER_DONE",
+                             "--signal AS3UPGRADE_DONE",
+                             "&>> /var/log/cloud/aws/install.log < /dev/null &"
+                            ]
+                           ]
+                    },
+                    "cwd" : "/config/cloud"
+                  }
+            },
+            "files": {
+                "/config/cloud/f5-appsvcs-3.13.2-1.noarch.rpm": {
+                    "group": "root",
+                    "mode": "000755",
+                    "owner": "root",
+                    "source": {"Ref": "as3rpmUrl"}
+                   },
+                "/config/cloud/install-rpm.sh": {
+                    "group": "root",
+                    "mode": "000755",
+                    "owner": "root",
+                    "source": {"Ref": "as3InstallFileUrl"}
+                   }
+            }
+        },
         "bigipstig": {
             "commands": {
                 "081-apply-stigs": {
@@ -2858,7 +2995,7 @@
                                 "--file /config/bigipstig.sh",
                                 "--output /var/log/bigipstig.log",
                                 "--log-level silly",
-                                "--wait-for CLUSTER_DONE",
+                                "--wait-for AS3UPGRADE_DONE",
                                 "--signal BIGIPSTIG_DONE",
                                 "&>> /var/log/cloud/aws/install.log < /dev/null &"
                             ]
@@ -2894,7 +3031,7 @@
                                [
                                    "SCCA",
                                    "--wait-for BIGIPSTIG_DONE",
-                                   "--wait-for PASSWORD_REMOVED"
+                                   "--wait-for AS3UPGRADE_DONE"
                                ]
                         },
                          "--signal SIGNAL_RESOURCE_COMPLETE",

--- a/BIG-IP/template.json
+++ b/BIG-IP/template.json
@@ -142,6 +142,7 @@
         "Parameters": [
          "pVpcStackName",
          "pTier",
+         "internalRoutesGWIP",
          "numberOfAdditionalNics",
          "additionalNicLocation"
         ]
@@ -203,6 +204,9 @@
         },
        "pTier": {
         "default": "Tier1 or Tier2. Defines which Tier of the architecture the BIG-IP devices will sit in."
+        },
+        "internalRoutesGWIP": {
+         "default": "GW IP address for routes to point via Internal interface."
         },
        "pBaselineCompliance": {
         "default": "Choose your baseline compliance posture"
@@ -552,6 +556,10 @@
         "ConstraintDescription": "Must be Tier1 or Tier2.",
         "Type": "String",
         "Default": "Tier1"
+       },
+       "internalRoutesGWIP": {
+        "Type": "String",
+        "Default": "10.0.3.1"
        },
      "pBaselineCompliance": {
       "AllowedValues" : ["Enterprise", "SCCA"],
@@ -1469,6 +1477,32 @@
         },
         "AS3-baseline-routing": {
             "commands": {
+                "010-apply-device-routes": { 
+                    "test" : "[ -f /config/deployDeviceRoutes.sh ]",
+                    "command": { 
+                       "Fn::Join": [  
+                        " ", 
+                        [ 
+                         "nohup /config/waitThenRun.sh",
+                         "f5-rest-node /config/cloud/aws/node_modules/@f5devcentral/f5-cloud-libs/scripts/runScript.js",
+                         "--file /config/deployDeviceRoutes.sh",
+                         "--output /var/log/deployDeviceRoutes.log",
+                         "--log-level silly",
+                         {
+                            "Fn::If":
+                               [
+                                   "SCCA",
+                                   "--wait-for CERTS_DONE",
+                                   "--wait-for PASSWORD_REMOVED"
+                               ]
+                        },
+                         "--signal DEVICE_ROUTES_DONE",
+                         "&>> /var/log/cloud/aws/install.log < /dev/null &"
+                        ] 
+                       ] 
+                  }, 
+                  "cwd" : "/config"  
+                  }, 
                 "083-apply-AS3-baseline-routing": { 
                     "test" : "[ -f /config/deployBaselineRouting.sh ]",
                     "command": { 
@@ -1480,14 +1514,7 @@
                          "--file /config/deployBaselineRouting.sh",
                          "--output /var/log/deployBaselineRouting.log",
                          "--log-level silly",
-                         {
-                            "Fn::If":
-                               [
-                                   "SCCA",
-                                   "--wait-for CERTS_DONE",
-                                   "--wait-for PASSWORD_REMOVED"
-                               ]
-                        },
+                         "--wait-for DEVICE_ROUTES_DONE",
                          "--signal AS3_ROUTING_DONE",
                          "&>> /var/log/cloud/aws/install.log < /dev/null &"
                         ] 
@@ -1498,6 +1525,31 @@
                   
             },
             "files": {
+                "/config/deployDeviceRoutes.sh": {
+                    "group": "root",
+                    "mode": "000755",
+                    "owner": "root",
+                    "content": {
+                        "Fn::Join": [
+                            "",
+                            [
+                            "#!/bin/bash\n",
+                            "gw='",
+                            {
+                                "Ref": "internalRoutesGWIP"
+                            },
+                            "'\n",
+                            "\n",
+                            "echo  -e 'create cli transaction;\n",
+                            "create net route 10.0.0.0/8 gw '${gw}'\n",
+                            "create net route 172.16.0.0/12 gw '${gw}'\n",
+                            "create net route 192.168.0.0/16 gw '${gw}'\n",
+                            "save /sys config\n",
+                            "submit cli transaction' | tmsh -q\n"
+                            ]
+                        ]
+                    }
+                },
                 "/config/deployBaselineRouting.sh": {
                     "group": "root",
                     "mode": "000755",
@@ -1544,7 +1596,7 @@
                             ]
                         ]
                     }
-                }   
+                }    
             }
         },
         "mgmt-baseline": {

--- a/BIG-IP/template.json
+++ b/BIG-IP/template.json
@@ -361,6 +361,7 @@
       }
      },
      "Bigip1VipEipAddress": {
+      "Condition": "Tier1",
       "Description": "EIP address for VIP",
       "Value": {
        "Fn::Join": [
@@ -399,6 +400,7 @@
       }
      },
      "Bigip1subnet1Az1SelfEipAddress": {
+      "Condition":"Tier1",
       "Description": "IP Address of the External interface attached to BIG-IP",
       "Value": {
        "Ref": "Bigip1subnet1Az1SelfEipAddress"
@@ -488,6 +490,7 @@
       }
      },
      "Bigip2subnet1Az1SelfEipAddress": {
+      "Condition":"Tier1",
       "Description": "IP Address of the External interface attached to BIG-IP",
       "Value": {
        "Ref": "Bigip2subnet1Az1SelfEipAddress"
@@ -1059,11 +1062,22 @@
                ]
               },
               "'\n",
-              "VIPEIP='",
-              {
-               "Ref": "Bigip1VipEipAddress"
-              },
-              "'\n",
+              { "Fn::If" : [
+                "Tier1",
+                { "Fn::Join": [
+                  "",
+                  [
+                    "VIPEIP='",
+                    {
+                     "Ref": "Bigip1VipEipAddress"
+                    },
+                    "'\n"
+                    ]
+                  ]
+                },
+                ""
+              ]
+             },
               "PROGNAME=$(basename $0)\n",
               "function error_exit {\n",
               "echo \"${PROGNAME}: ${1:-\\\"Unknown Error\\\"}\" 1>&2\n",
@@ -2101,12 +2115,14 @@
       "Type": "AWS::EC2::NetworkInterface"
      },
      "Bigip1VipEipAddress": {
+      "Condition":"Tier1",
       "Properties": {
        "Domain": "vpc"
       },
       "Type": "AWS::EC2::EIP"
      },
      "Bigip1VipEipAssociation": {
+      "Condition":"Tier1",
       "Properties": {
        "AllocationId": {
         "Fn::GetAtt": [
@@ -2167,12 +2183,14 @@
       "Type": "AWS::EC2::NetworkInterface"
      },
      "Bigip1subnet1Az1SelfEipAddress": {
+      "Condition":"Tier1",
       "Properties": {
        "Domain": "vpc"
       },
       "Type": "AWS::EC2::EIP"
      },
      "Bigip1subnet1Az1SelfEipAssociation": {
+      "Condition":"Tier1",
       "Properties": {
        "AllocationId": {
         "Fn::GetAtt": [
@@ -3071,12 +3089,14 @@
       "Type": "AWS::EC2::NetworkInterface"
      },
      "Bigip2subnet1Az1SelfEipAddress": {
+      "Condition":"Tier1",
       "Properties": {
        "Domain": "vpc"
       },
       "Type": "AWS::EC2::EIP"
      },
      "Bigip2subnet1Az1SelfEipAssociation": {
+      "Condition":"Tier1",
       "Properties": {
        "AllocationId": {
         "Fn::GetAtt": [

--- a/DemoApp/demoApp.json
+++ b/DemoApp/demoApp.json
@@ -1,6 +1,6 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description" : "Installing Cloudformation helper scripts in Ubuntu 16.04 LTS, starting reference for template was at https://github.com/awslabs/aws-cloudformation-templates/tree/master/aws/solutions/HelperNonAmaznAmi",
+    "Description" : "Installing Cloudformation helper scripts in Ubuntu Ubuntu16 LTS, starting reference for template was at https://github.com/awslabs/aws-cloudformation-templates/tree/master/aws/solutions/HelperNonAmaznAmi",
     "Parameters" : {
       "sshKey": {
         "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instance",
@@ -12,7 +12,14 @@
         "Default" : "t2.small",
         "AllowedValues" : [ "t1.micro", "t2.nano", "t2.micro", "t2.small", "t2.medium", "t2.large", "m1.small", "m1.medium", "m1.large", "m1.xlarge", "m2.xlarge", "m2.2xlarge", "m2.4xlarge", "m3.medium", "m3.large", "m3.xlarge", "m3.2xlarge", "m4.large", "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge", "c1.medium", "c1.xlarge", "c3.large", "c3.xlarge", "c3.2xlarge", "c3.4xlarge", "c3.8xlarge", "c4.large", "c4.xlarge", "c4.2xlarge", "c4.4xlarge", "c4.8xlarge", "g2.2xlarge", "g2.8xlarge", "r3.large", "r3.xlarge", "r3.2xlarge", "r3.4xlarge", "r3.8xlarge", "i2.xlarge", "i2.2xlarge", "i2.4xlarge", "i2.8xlarge", "d2.xlarge", "d2.2xlarge", "d2.4xlarge", "d2.8xlarge", "hi1.4xlarge", "hs1.8xlarge", "cr1.8xlarge", "cc2.8xlarge", "cg1.4xlarge"],
         "ConstraintDescription" : "must be a valid EC2 instance type."
-      },  
+      },
+      "ubuntuVersion": {
+        "Description" : "Ubuntu Version",
+        "Type" : "String",
+        "Default" : "Ubuntu16",
+        "AllowedValues" : [ "Ubuntu16", "Ubuntu18"],
+        "ConstraintDescription" : "must be a valid EC2 instance type."
+      },
       "SSHLocation" : {
         "Description" : "The IP address range that can be used to SSH to the EC2 instances",
         "Type": "String",
@@ -22,66 +29,61 @@
         "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
         "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
      },
-     "pVpcStackName" : {
+     "vpcStackName" : {
           "Description" : "Name of the Stack that deployed the VPC",
-          "Type": "String",
-          "Default": "VDSS"
+          "Type": "String"
+     },
+     "demoAppPrivateIP": {
+        "Description" : "Private IP for NIC",
+        "Type": "String"
      }
     },
     "Mappings": {
-      "AWSRegionAMIEC2" : {
-        "us-east-1"        : {"Ubuntu16" : "ami-d15a75c7"},
-        "us-east-2"        : {"Ubuntu16" : "ami-8b92b4ee"},
-        "us-west-2"        : {"Ubuntu16" : "ami-746aba14"},
-        "us-west-1"        : {"Ubuntu16" : "ami-a9a8e4c9"},
-        "eu-west-1"        : {"Ubuntu16" : "ami-844e0bf7"},
-        "eu-central-1"     : {"Ubuntu16" : "ami-a9a557c6"},
-        "ap-northeast-1"   : {"Ubuntu16" : "ami-d82efcb9"},
-        "ap-southeast-1"   : {"Ubuntu16" : "ami-d554f1b6"},
-        "ap-southeast-2"   : {"Ubuntu16" : "ami-0bc1f168"},
-        "us-gov-west-1"    : {"Ubuntu16" : "ami-939412f2"},
-        "us-gov-east-1"    : {"Ubuntu16" : "ami-9350b7e2"}
-        }
-    },         
+        "AWSRegionAMIEC2" : {
+            "us-east-1"        : {"Ubuntu16" : "ami-d15a75c7", "Ubuntu18" : "ami-064a0193585662d74"},
+            "us-east-2"        : {"Ubuntu16" : "ami-8b92b4ee", "Ubuntu18" : "ami-021b7b04f1ac696c2"},
+            "us-west-2"        : {"Ubuntu16" : "ami-746aba14", "Ubuntu18" : "ami-09a3d8a7177216dcf"},
+            "us-west-1"        : {"Ubuntu16" : "ami-a9a8e4c9", "Ubuntu18" : "ami-056d04da775d124d7"},
+            "eu-west-1"        : {"Ubuntu16" : "ami-844e0bf7", "Ubuntu18" : "ami-01cca82393e531118"},
+            "eu-central-1"     : {"Ubuntu16" : "ami-a9a557c6", "Ubuntu18" : "ami-0cdab515472ca0bac"},
+            "ap-northeast-1"   : {"Ubuntu16" : "ami-d82efcb9", "Ubuntu18" : "ami-0cb1c8cab7f5249b6"},
+            "ap-southeast-1"   : {"Ubuntu16" : "ami-d554f1b6", "Ubuntu18" : "ami-099d318f80eab7e94"},
+            "ap-southeast-2"   : {"Ubuntu16" : "ami-0bc1f168", "Ubuntu18" : "ami-08a648fb5cc86fb74"},
+            "us-gov-west-1"    : {"Ubuntu16" : "ami-939412f2", "Ubuntu18" : "ami-60501e01"},
+            "us-gov-east-1"    : {"Ubuntu16" : "ami-9350b7e2", "Ubuntu18" : "ami-cce606bd"}
+            },
+          "UbuntuVersionSources" : {
+            "Ubuntu16" : { "cmd": "deb https://nginx.org/packages/mainline/ubuntu/ xenial nginx\ndeb-src https://nginx.org/packages/mainline/ubuntu/ xenial nginx\n"},
+            "Ubuntu18" : { "cmd": "deb https://nginx.org/packages/mainline/ubuntu/ bionic nginx\ndeb-src https://nginx.org/packages/mainline/ubuntu/ bionic nginx\n"}
+          }
+    },      
    "Resources" : {
-      "JumpHostNetworkInterface": {
+      "networkInterface": {
         "Properties": {
-         "Description": "Public External Interface for the IPS",
+         "PrivateIpAddress": {
+            "Ref": "demoAppPrivateIP"
+           },
+         "Description": "Public External Interface",
          "GroupSet": [
           {
-           "Ref": "JumpHostSecurityGroup"
+           "Ref": "securityGroup"
           }
          ],
          "SourceDestCheck": false,
          "SubnetId": {
-            "Fn::ImportValue" : {"Fn::Sub": "${pVpcStackName}-VdssManagementSubnetId" }
-         }
+            "Fn::ImportValue" : {"Fn::Sub": "${vpcStackName}-AppSubnetAID" }
+         },
+         "Tags": [
+            {
+                "Key" : "Application",
+                "Value" : "demoApp"
+            }
+            ]
         },
         "Type": "AWS::EC2::NetworkInterface"
        },
-       "JumpHostEipAddress": {
-        "Properties": {
-         "Domain": "vpc"
-        },
-        "Type": "AWS::EC2::EIP"
-       },
-       "JumpHostEipAddressAssociation": {
-        "Properties": {
-         "AllocationId": {
-          "Fn::GetAtt": [
-           "JumpHostEipAddress",
-           "AllocationId"
-          ]
-         },
-         "NetworkInterfaceId": {
-          "Ref": "JumpHostNetworkInterface"
-         }
-        },
-        "Type": "AWS::EC2::EIPAssociation"
-       },
       "EC2Instance" : {
         "Type" : "AWS::EC2::Instance",
-        "DependsOn": "JumpHostEipAddressAssociation",
         "CreationPolicy" : {
           "ResourceSignal" : {
             "Timeout" : "PT10M",
@@ -91,7 +93,9 @@
         "Metadata" : {
           "AWS::CloudFormation::Init" : {
             "configSets" : {
-              "full_install" : [ "install_and_enable_cfn_hup" ]
+              "full_install" : [ "install_and_enable_cfn_hup" ],
+              "install_nginx" : [ "install_and_enable_cfn_hup", "install_nginx" ],
+			  "install_docker" : [ "install_and_enable_cfn_hup", "install_docker" ]
             },
             "install_and_enable_cfn_hup" : {
               "files" : {
@@ -113,7 +117,7 @@
                               "action=/opt/aws/bin/cfn-init -v ",
                               "         --stack ", { "Ref" : "AWS::StackName" },
                               "         --resource EC2Instance ",
-                              "         --configsets full_install ",
+                              "         --configsets install_docker ",
                               "         --region ", { "Ref" : "AWS::Region" }, "\n",
                               "runas=root\n"
                             ]]}
@@ -138,7 +142,49 @@
                         "command" : "systemctl start cfn-hup.service"
                     }
                 }
-             }
+             },
+             "install_nginx": {
+               "files": {
+                 "/etc/apt/sources.list.d/nginx.list": {
+                    "content": {
+                      "Fn::FindInMap": [ "UbuntuVersionSources", { "Ref": "ubuntuVersion" }, "cmd"]
+                    }
+                  }
+                },
+                "commands": {
+                  "010-download_key_and_install_nginx": {
+                     "command": {
+                        "Fn::Join": [
+                        "\n",
+                        [
+                          "wget https://nginx.org/keys/nginx_signing.key",
+                          "apt-key add nginx_signing.key",
+                          "apt-get update",
+                          "sudo apt-get install nginx",
+                          "nginx"
+                        ]
+                        ]
+                     }
+                  }
+                }
+             },
+			 "install_docker": {
+			   "files": {
+			   },
+			   "commands": {
+                 "010-install-docker": {
+                     "command": {
+                        "Fn::Join": [
+                        "\n",
+                        [
+						  "sudo apt-get install -y docker.io",
+						  "sudo docker run -d -p 80:80 --net=host --restart unless-stopped -e F5DEMO_APP=website -e F5DEMO_NODENAME='F5 Secure Cloud Architecture' -e F5DEMO_COLOR=ffd734 -e F5DEMO_NODENAME_SSL='F5 Secure Cloud Architecture (SSL)' -e F5DEMO_COLOR_SSL=a0bf37 chen23/f5-demo-app:ssl"
+                        ]
+                        ]
+                     }
+                  }
+			   }
+			 }
           }
         },
         "Properties" : {
@@ -149,38 +195,28 @@
              "Description": "Public or External Interface of IPS",
              "DeviceIndex": "0",
              "NetworkInterfaceId": {
-              "Ref": "JumpHostNetworkInterface"
+              "Ref": "networkInterface"
              }
             }
            ],
           "Tags": [
             {
              "Key": "Name",
-             "Value": {
-              "Fn::Join": [
-               "",
-               [
-                "IPS:",
-                {
-                 "Ref": "AWS::StackName"
-                }
-               ]
-              ]
-             }
+             "Value": {"Fn::Sub": "${AWS::StackName}-ubuntu-VM" }
             }
            ],
-          "ImageId" : {"Fn::FindInMap": [ "AWSRegionAMIEC2", { "Ref": "AWS::Region" },"Ubuntu16"]},
+          "ImageId" : {"Fn::FindInMap": [ "AWSRegionAMIEC2", { "Ref": "AWS::Region" },{ "Ref": "ubuntuVersion" }]},
           "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
                "#!/bin/bash -xe\n",
                "apt-get update -y\n",
                "apt-get install -y python-setuptools\n",
                "mkdir -p /opt/aws/bin\n",
                "wget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n",
-               "easy_install --script-dir /opt/aws/bin aws-cfn-bootstrap-latest.tar.gz\n",
+               "sudo python /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin aws-cfn-bootstrap-latest.tar.gz\n",
                 "/opt/aws/bin/cfn-init -v ",
                "         --stack ", { "Ref" : "AWS::StackName" },
                "         --resource EC2Instance ",
-               "         --configsets full_install ",
+               "         --configsets install_docker ",
                "         --region ", { "Ref" : "AWS::Region" }, "\n",
   
                "/opt/aws/bin/cfn-signal -e $? ",
@@ -189,9 +225,9 @@
                "         --region ", { "Ref" : "AWS::Region" }, "\n"
               ]]}}}
       },
-      "JumpHostSecurityGroup": {
+      "securityGroup": {
         "Properties": {
-         "GroupDescription": "Public or external interface rules for jumphost interface",
+         "GroupDescription": "Public or external interface rules for interface",
          "SecurityGroupIngress": [
           {
            "CidrIp": "0.0.0.0/0",
@@ -221,21 +257,11 @@
          "Tags": [
           {
            "Key": "Name",
-           "Value": {
-            "Fn::Join": [
-             "",
-             [
-              "JumpHost Security Group:",
-              {
-               "Ref": "AWS::StackName"
-              }
-             ]
-            ]
-           }
+           "Value": {"Fn::Sub": "${AWS::StackName}-securityGroup" }
           }
          ],
          "VpcId": {
-          "Fn::ImportValue" : {"Fn::Sub": "${pVpcStackName}-VdssVpcId" }
+          "Fn::ImportValue" : {"Fn::Sub": "${vpcStackName}-AppVpcId" }
          }
         },
         "Type": "AWS::EC2::SecurityGroup"
@@ -245,30 +271,30 @@
     "StackName": {
         "Value": {
          "Ref": "AWS::StackName"
-        }
-    },
-    "JumpHostEipAddress": {
-        "Description": "Public IP address of the JumpHost",
-        "Value": {
-         "Ref": "JumpHostEipAddress"
-        }
-       },
-    "JumpHostPrivateIp": {
-        "Description": "Internally routable IP of the jump host",
-        "Value": {
-         "Fn::GetAtt": [
-          "JumpHostNetworkInterface",
-          "PrimaryPrivateIpAddress"
-         ]
-        }
-       },
-    "JumpHostNetworkInterface": {
-        "Description": "Network interface of JumpHost",
-        "Value": {
-         "Ref": "JumpHostNetworkInterface"
         },
         "Export" : {
-            "Name" : {"Fn::Sub": "${AWS::StackName}-JumpHostNetworkInterface" }
+            "Name" : {"Fn::Sub": "${AWS::StackName}-StackName" }
+        }
+    },
+    "privateIp": {
+        "Description": "Internally routable IP",
+        "Value": {
+         "Fn::GetAtt": [
+          "networkInterface",
+          "PrimaryPrivateIpAddress"
+         ]
+        },
+        "Export" : {
+            "Name" : {"Fn::Sub": "${AWS::StackName}-privateIp" }
+        }
+       },
+    "networkInterface": {
+        "Description": "Network interface",
+        "Value": {
+         "Ref": "networkInterface"
+        },
+        "Export" : {
+            "Name" : {"Fn::Sub": "${AWS::StackName}-networkInterface" }
         }
     }
   }

--- a/IPS/template.json
+++ b/IPS/template.json
@@ -371,6 +371,19 @@
             "Name" : {"Fn::Sub": "${AWS::StackName}-IpsExternalInterface" }
         }
     },
+    "IpsExternalInterfaceIPAddress": {
+        "Description": "External IP of IPS",
+        "Value":
+        {
+            "Fn::GetAtt": [
+              "IpsExternalInterface",
+              "PrimaryPrivateIpAddress"
+            ]
+        },
+        "Export" : {
+            "Name" : {"Fn::Sub": "${AWS::StackName}-IpsExternalInterfaceIPAddress" }
+        }
+    },
     "IpsInternalInterface": {
         "Description": "Internal interface of IPS",
         "Value": {
@@ -378,6 +391,19 @@
         },
         "Export" : {
             "Name" : {"Fn::Sub": "${AWS::StackName}-IpsInternalInterface" }
+        }
+    },
+    "IpsInternalInterfaceIPAddress": {
+        "Description": "Internal IP of IPS",
+        "Value":
+        {
+            "Fn::GetAtt": [
+              "IpsInternalInterface",
+              "PrimaryPrivateIpAddress"
+            ]
+        },
+        "Export" : {
+            "Name" : {"Fn::Sub": "${AWS::StackName}-IpsInternalInterfaceIPAddress" }
         }
     }
   }

--- a/VPC/aws-scca-app-vpc.json
+++ b/VPC/aws-scca-app-vpc.json
@@ -5,12 +5,30 @@
             "Default": "SCCA-App-Demo",
             "Description": "Project name to use for tagging"
         },
+        "pVdssVpcCidr": {
+            "Type": "String",
+            "Default": "10.0.0.0/16",
+            "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+            "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x.",
+            "Description": "CIDR Block for the VDSS VPC",
+            "MaxLength": 18,
+            "MinLength": 9
+        },
         "pAppVpcCidr": {
             "Type": "String",
             "Default": "10.1.0.0/16",
             "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
             "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x.",
-            "Description": "CIDR Block for the app VPC",
+            "Description": "CIDR Block for the App VPC",
+            "MaxLength": 18,
+            "MinLength": 9
+        },
+        "pFargateVpcCidr": {
+            "Type": "String",
+            "Default": "10.2.0.0/16",
+            "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+            "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x.",
+            "Description": "CIDR Block for the App VPC",
             "MaxLength": 18,
             "MinLength": 9
         },
@@ -382,7 +400,49 @@
                  }
              }
          }
-        }
+        },
+        "rAppRouteToVdss" : {
+            "Type" : "AWS::EC2::Route",
+            "DependsOn" : "rAppTransitGatewayAttachement",
+            "Properties" : {
+              "RouteTableId" : { "Ref" : "rAppMainRouteTable" },
+              "DestinationCidrBlock" : { "Ref" : "pVdssVpcCidr" },
+              "TransitGatewayId": {
+               "Fn::ImportValue": {
+                   "Fn::Join": [
+                     "",
+                     [
+                         {
+                             "Ref": "pTransitGatewayStackName"
+                         },
+                         "-SccaTgwId"
+                     ]
+                   ]
+                 }
+             }
+         }
+        }, 
+        "rAppRouteToFargateVpc" : {
+            "Type" : "AWS::EC2::Route",
+            "DependsOn" : "rAppTransitGatewayAttachement",
+            "Properties" : {
+              "RouteTableId" : { "Ref" : "rAppMainRouteTable" },
+              "DestinationCidrBlock" : { "Ref" : "pFargateVpcCidr" },
+              "TransitGatewayId": {
+               "Fn::ImportValue": {
+                   "Fn::Join": [
+                     "",
+                     [
+                         {
+                             "Ref": "pTransitGatewayStackName"
+                         },
+                         "-SccaTgwId"
+                     ]
+                   ]
+                 }
+             }
+         }
+        }       
     }, 
     "Outputs": {
         "StackName": {

--- a/VPC/aws-scca-app-vpc.json
+++ b/VPC/aws-scca-app-vpc.json
@@ -568,6 +568,32 @@
                 }
             }
         },
+        "demoAppPrivateIP": {
+            "Value": {
+                "Fn::Join": [
+                    ".",
+                    [
+                        {"Fn::Select" : [ 0, { "Fn::Split": [ ".", { "Fn::Select" : [ 0, { "Fn::Cidr": [ { "Ref": "pAppVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 1, { "Fn::Split": [ ".", { "Fn::Select" : [ 0, { "Fn::Cidr": [ { "Ref": "pAppVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 2, { "Fn::Split": [ ".", { "Fn::Select" : [ 0, { "Fn::Cidr": [ { "Ref": "pAppVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        "50"
+                    ]
+                ]
+             },
+             "Export": {
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "AWS::StackName"
+                            },
+                            "-demoAppPrivateIP"
+                        ]
+                    ]
+                }
+            }
+        },
         "AppSubnetPeertId": {
             "Value": {
                 "Ref": "rAppSubnetPeer"

--- a/VPC/aws-scca-fargate-vpc.json
+++ b/VPC/aws-scca-fargate-vpc.json
@@ -5,12 +5,30 @@
             "Default": "SCCA-App-Demo",
             "Description": "Project name to use for tagging"
         },
+        "pVdssVpcCidr": {
+            "Type": "String",
+            "Default": "10.0.0.0/16",
+            "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+            "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x.",
+            "Description": "CIDR Block for the VDSS VPC",
+            "MaxLength": 18,
+            "MinLength": 9
+        },
+        "pAppVpcCidr": {
+            "Type": "String",
+            "Default": "10.1.0.0/16",
+            "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+            "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x.",
+            "Description": "CIDR Block for the App VPC",
+            "MaxLength": 18,
+            "MinLength": 9
+        },
         "pFargateVpcCidr": {
             "Type": "String",
             "Default": "10.2.0.0/16",
             "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
             "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x.",
-            "Description": "CIDR Block for the app VPC",
+            "Description": "CIDR Block for the App VPC",
             "MaxLength": 18,
             "MinLength": 9
         },
@@ -382,7 +400,49 @@
                  }
             }
         }
-      }
+        },
+        "FargateRouteToVdss" : {
+          "Type" : "AWS::EC2::Route",
+          "DependsOn" : "rFargateTransitGatewayAttachement",
+          "Properties" : {
+            "RouteTableId" : { "Ref" : "rFargateMainRouteTable" },
+            "DestinationCidrBlock" : { "Ref" : "pVdssVpcCidr" },
+            "TransitGatewayId": {
+              "Fn::ImportValue": {
+                "Fn::Join": [
+                  "",
+                  [
+                   {
+                    "Ref": "pTransitGatewayStackName"
+                   },
+                   "-SccaTgwId"
+                  ]
+                ]
+              }
+            }
+          }
+        },
+        "FargateRouteToAppVpc" : {
+            "Type" : "AWS::EC2::Route",
+            "DependsOn" : "rFargateTransitGatewayAttachement",
+            "Properties" : {
+            "RouteTableId" : { "Ref" : "rFargateMainRouteTable" },
+            "DestinationCidrBlock" : { "Ref" : "pAppVpcCidr" },
+            "TransitGatewayId": {
+            "Fn::ImportValue": {
+                "Fn::Join": [
+                    "",
+                    [
+                        {
+                            "Ref": "pTransitGatewayStackName"
+                        },
+                        "-SccaTgwId"
+                    ]
+                ]
+                }
+            }
+        }
+        }
     },
     "Outputs": {
         "StackName": {

--- a/VPC/aws-scca-vdss-stack-singleAZ.json
+++ b/VPC/aws-scca-vdss-stack-singleAZ.json
@@ -1083,6 +1083,84 @@
                 }
             }
         },
+        "ExternalTierVIP": {
+            "Value": {
+                "Fn::Join": [
+                    ".",
+                    [
+                        {"Fn::Select" : [ 0, { "Fn::Split": [ ".", { "Fn::Select" : [ 0, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 1, { "Fn::Split": [ ".", { "Fn::Select" : [ 0, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 2, { "Fn::Split": [ ".", { "Fn::Select" : [ 0, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        "50"
+                    ]
+                ]
+             },
+             "Export": {
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "AWS::StackName"
+                            },
+                            "-ExternalTierVIP"
+                        ]
+                    ]
+                }
+            }
+        },
+        "extSelfIPInternalTier": {
+            "Value": {
+                "Fn::Join": [
+                    ".",
+                    [
+                        {"Fn::Select" : [ 0, { "Fn::Split": [ ".", { "Fn::Select" : [ 2, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 1, { "Fn::Split": [ ".", { "Fn::Select" : [ 2, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 2, { "Fn::Split": [ ".", { "Fn::Select" : [ 2, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        "10"
+                    ]
+                ]
+             },
+             "Export": {
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "AWS::StackName"
+                            },
+                            "-extSelfIPInternalTier"
+                        ]
+                    ]
+                }
+            }
+        },
+        "extSelfIPExternalTier": {
+            "Value": {
+                "Fn::Join": [
+                    ".",
+                    [
+                        {"Fn::Select" : [ 0, { "Fn::Split": [ ".", { "Fn::Select" : [ 0, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 1, { "Fn::Split": [ ".", { "Fn::Select" : [ 0, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 2, { "Fn::Split": [ ".", { "Fn::Select" : [ 0, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        "10"
+                    ]
+                ]
+             },
+             "Export": {
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "AWS::StackName"
+                            },
+                            "-extSelfIPExternalTier"
+                        ]
+                    ]
+                }
+            }
+        },
         "VdssVpcId": {
             "Value": {
                 "Ref": "rVdssVpc"

--- a/VPC/aws-scca-vdss-stack-singleAZ.json
+++ b/VPC/aws-scca-vdss-stack-singleAZ.json
@@ -1031,6 +1031,58 @@
                 }
             }
         },
+        "InsideSubnetGWIP": {
+            "Value": {
+                "Fn::Join": [
+                    ".",
+                    [
+                        {"Fn::Select" : [ 0, { "Fn::Split": [ ".", { "Fn::Select" : [ 3, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 1, { "Fn::Split": [ ".", { "Fn::Select" : [ 3, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 2, { "Fn::Split": [ ".", { "Fn::Select" : [ 3, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        "1"
+                    ]
+                ]
+             },
+             "Export": {
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "AWS::StackName"
+                            },
+                            "-InsideSubnetGWIP"
+                        ]
+                    ]
+                }
+            }
+        },
+        "InternalTierVIP": {
+            "Value": {
+                "Fn::Join": [
+                    ".",
+                    [
+                        {"Fn::Select" : [ 0, { "Fn::Split": [ ".", { "Fn::Select" : [ 2, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 1, { "Fn::Split": [ ".", { "Fn::Select" : [ 2, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        {"Fn::Select" : [ 2, { "Fn::Split": [ ".", { "Fn::Select" : [ 2, { "Fn::Cidr": [ { "Ref": "pVdssVpcCidr" }, 16, "8" ] } ] } ] } ]},
+                        "50"
+                    ]
+                ]
+             },
+             "Export": {
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "AWS::StackName"
+                            },
+                            "-InternalTierVIP"
+                        ]
+                    ]
+                }
+            }
+        },
         "VdssVpcId": {
             "Value": {
                 "Ref": "rVdssVpc"

--- a/VPC/aws-scca-vdss-stack-singleAZ.json
+++ b/VPC/aws-scca-vdss-stack-singleAZ.json
@@ -14,6 +14,24 @@
             "MaxLength": 18,
             "MinLength": 9
         },
+        "pAppVpcCidr": {
+            "Type": "String",
+            "Default": "10.1.0.0/16",
+            "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+            "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x.",
+            "Description": "CIDR Block for the App VPC",
+            "MaxLength": 18,
+            "MinLength": 9
+        },
+        "pFargateVpcCidr": {
+            "Type": "String",
+            "Default": "10.2.0.0/16",
+            "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+            "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x.",
+            "Description": "CIDR Block for the App VPC",
+            "MaxLength": 18,
+            "MinLength": 9
+        },
         "pTransitGatewayStackName": {
             "Type": "String",
             "Default": "SccaTgwStack",
@@ -542,6 +560,36 @@
                 "aws:cdk:path": "SccaVdssStack/rVdssOutsideRouteTableIgwRoute"
             }
         },
+        "rVdssManagementRouteTableAppVpcRoute": {
+            "Type": "AWS::EC2::Route",
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "rVdssManagementRouteTable"
+                },
+                "DestinationCidrBlock": { "Ref" : "pAppVpcCidr" },
+                "GatewayId": {
+                    "Ref": "rVdssIgw"
+                }
+            },
+            "Metadata": {
+                "aws:cdk:path": "SccaVdssStack/rVdssManagementRouteTableAppVpcRoute"
+            }
+        },
+        "rVdssManagementRouteTableFargateVpcRoute": {
+            "Type": "AWS::EC2::Route",
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "rVdssManagementRouteTable"
+                },
+                "DestinationCidrBlock": { "Ref" : "pFargateVpcCidr" },
+                "GatewayId": {
+                    "Ref": "rVdssIgw"
+                }
+            },
+            "Metadata": {
+                "aws:cdk:path": "SccaVdssStack/rVdssManagementRouteTableFargateVpcRoute"
+            }
+        },
         "rVdssManagementSubnet": {
             "Type": "AWS::EC2::Subnet",
             "Properties": {
@@ -790,6 +838,48 @@
             "Properties" : {
               "RouteTableId" : { "Ref" : "rVdssInternalRouteTable" },
               "DestinationCidrBlock" : "192.168.0.0/16",
+              "TransitGatewayId": {
+               "Fn::ImportValue": {
+                   "Fn::Join": [
+                     "",
+                     [
+                         {
+                             "Ref": "pTransitGatewayStackName"
+                         },
+                         "-SccaTgwId"
+                     ]
+                   ]
+                 }
+             }
+         }
+        },
+        "rInternalAppVPC" : {
+            "Type" : "AWS::EC2::Route",
+            "DependsOn" : "rTransitGatewayAttachement",
+            "Properties" : {
+              "RouteTableId" : { "Ref" : "rVdssInternalRouteTable" },
+              "DestinationCidrBlock" : { "Ref" : "pAppVpcCidr" },
+              "TransitGatewayId": {
+               "Fn::ImportValue": {
+                   "Fn::Join": [
+                     "",
+                     [
+                         {
+                             "Ref": "pTransitGatewayStackName"
+                         },
+                         "-SccaTgwId"
+                     ]
+                   ]
+                 }
+             }
+         }
+        },
+        "rInternalFargateVPC" : {
+            "Type" : "AWS::EC2::Route",
+            "DependsOn" : "rTransitGatewayAttachement",
+            "Properties" : {
+              "RouteTableId" : { "Ref" : "rVdssInternalRouteTable" },
+              "DestinationCidrBlock" : { "Ref" : "pFargateVpcCidr" },
               "TransitGatewayId": {
                "Fn::ImportValue": {
                    "Fn::Join": [

--- a/aws-quickstart-scca-main-same-net.json
+++ b/aws-quickstart-scca-main-same-net.json
@@ -345,6 +345,12 @@
           },
           "pVdssVpcCidr": {
             "Ref": "pVdssVpcCidr"
+          },
+          "pAppVpcCidr": {
+            "Ref": "pAppVpcCidr"
+          },
+          "pFargateVpcCidr": {
+            "Ref": "pFargateVpcCidr"
           }
         },
         "Tags": [
@@ -375,8 +381,14 @@
               "Outputs.StackName"
             ]
           },
+          "pVdssVpcCidr": {
+            "Ref": "pVdssVpcCidr"
+          },
           "pAppVpcCidr": {
             "Ref": "pAppVpcCidr"
+          },
+          "pFargateVpcCidr": {
+            "Ref": "pFargateVpcCidr"
           }
         },
         "Tags": [
@@ -406,6 +418,12 @@
               "TransitGatewayStack",
               "Outputs.StackName"
             ]
+          },
+          "pVdssVpcCidr": {
+            "Ref": "pVdssVpcCidr"
+          },
+          "pAppVpcCidr": {
+            "Ref": "pAppVpcCidr"
           },
           "pFargateVpcCidr": {
             "Ref": "pFargateVpcCidr"

--- a/aws-quickstart-scca-main-same-net.json
+++ b/aws-quickstart-scca-main-same-net.json
@@ -499,6 +499,12 @@
             "Ref": "licenseKey2"
           },
           "pTier": "Tier1",
+          "internalRoutesGWIP": {
+            "Fn::GetAtt": [
+              "IPSStack",
+              "Outputs.IpsExternalInterfaceIPAddress"
+            ]
+          },
           "sshKey": {
             "Ref": "sshKey"
           },
@@ -546,6 +552,12 @@
             "Ref": "licenseKey4"
           },
           "pTier": "Tier2",
+          "internalRoutesGWIP": {
+            "Fn::GetAtt": [
+              "VdssStack",
+              "Outputs.InsideSubnetGWIP"
+            ]
+          },
           "sshKey": {
             "Ref": "sshKey"
           },

--- a/aws-quickstart-scca-main-same-net.json
+++ b/aws-quickstart-scca-main-same-net.json
@@ -19,8 +19,8 @@
             "default": "INSTANCE CONFIGURATION"
            },
            "Parameters": [
-            "instanceTypeTier1",
-            "instanceTypeTier2",
+            "instanceTypeExternalTier",
+            "instanceTypeInternalTier",
             "sshKey"
            ]
           },
@@ -50,11 +50,11 @@
           "pBaselineCompliance": {
             "default": "Baseline Compliance"
            },
-           "instanceTypeTier1": {
-            "default": "Instance Type (Tier 1)"
+           "instanceTypeExternalTier": {
+            "default": "Instance Type (External Tier)"
            },
-           "instanceTypeTier2": {
-            "default": "Instance Type (Tier 2)"
+           "instanceTypeInternalTier": {
+            "default": "Instance Type (Internal Tier)"
            },
            "sshKey": {
             "default": "SSH Key"
@@ -127,7 +127,7 @@
     }
   },
   "Parameters": {
-    "instanceTypeTier1": {
+    "instanceTypeExternalTier": {
         "AllowedValues": [
          "m5.xlarge",
          "m5.2xlarge",
@@ -165,7 +165,7 @@
         "Description": "Big-IP Tier 1: Size of the F5 BIG-IP Virtual Instance",
         "Type": "String"
        },
-    "instanceTypeTier2": {
+    "instanceTypeInternalTier": {
         "AllowedValues": [
          "m5.xlarge",
          "m5.2xlarge",
@@ -404,6 +404,46 @@
         "aws:cdk:path": "sccaMainStack/AppVPCStack"
       }
     },
+    "DemoApp": {
+        "Condition": "DeployDemoApps",
+        "Type": "AWS::CloudFormation::Stack",
+        "DependsOn": "RouteTableUpdates",
+        "Properties": {
+          "TemplateURL": {
+            "Fn::Sub": "https://${pQuickstartS3BucketName}.s3.amazonaws.com/${pQuickstartS3KeyPrefix}/DemoApp/demoApp.json"
+          },
+          "Parameters": {
+            "sshKey": {
+                "Ref": "sshKey"
+              },
+            "InstanceType": "t2.small",
+            "ubuntuVersion": "Ubuntu16",
+            "vpcStackName": {
+                "Fn::GetAtt": [
+                  "AppVpcStack",
+                  "Outputs.StackName"
+                ]
+              },
+            "demoAppPrivateIP": {
+            "Fn::GetAtt": [
+                "AppVpcStack",
+                "Outputs.demoAppPrivateIP"
+            ]
+            }
+          },
+          "Tags": [
+            {
+              "Key": "Project",
+              "Value": {
+                "Ref": "pProject"
+              }
+            }
+          ]
+        },
+        "Metadata": {
+          "aws:cdk:path": "sccaMainStack/DemoApp"
+        }
+      },
     "FargateVpcStack": {
       "Condition": "DeployDemoApps",
       "Type": "AWS::CloudFormation::Stack",
@@ -505,13 +545,43 @@
               "Outputs.IpsExternalInterfaceIPAddress"
             ]
           },
+          "demoAppVIP": {
+            "Fn::GetAtt": [
+                "VdssStack",
+                "Outputs.ExternalTierVIP"
+              ]
+           },
+          "extSelfIP": {
+            "Fn::GetAtt": [
+                "VdssStack",
+                "Outputs.extSelfIPExternalTier"
+              ]
+           },
+          "demoAppPoolMember": {
+            "Fn::GetAtt": [
+              "VdssStack",
+              "Outputs.InternalTierVIP"
+            ]
+          },
           "sshKey": {
             "Ref": "sshKey"
           },
+          "instanceType": {
+            "Ref": "instanceTypeExternalTier"
+           },
           "restrictedSrcAddress": "0.0.0.0/0",
           "declarationUrlrouting": {
             "Fn::Sub": "https://${pQuickstartS3BucketName}.s3.amazonaws.com/${pQuickstartS3KeyPrefix}/BIG-IP/atc/as3/mgmt_forwardingVIP.json"
-          }
+          },
+          "declarationUrldemoApp": {
+            "Fn::Sub": "https://${pQuickstartS3BucketName}.s3.amazonaws.com/${pQuickstartS3KeyPrefix}/BIG-IP/atc/as3/tier1/demoAppVIP-ExternalTier.json"
+          },
+          "as3rpmUrl": {
+            "Fn::Sub": "http://raw.githubusercontent.com/F5Networks/f5-appsvcs-extension/master/dist/lts/3.13.2/f5-appsvcs-3.13.2-1.noarch.rpm"
+           },
+         "as3InstallFileUrl": {
+            "Fn::Sub": "https://${pQuickstartS3BucketName}.s3.amazonaws.com/${pQuickstartS3KeyPrefix}/BIG-IP/atc/as3/install-rpm.sh"
+           } 
         },
         "Tags": [
           {
@@ -558,13 +628,43 @@
               "Outputs.InsideSubnetGWIP"
             ]
           },
+          "demoAppVIP": {
+            "Fn::GetAtt": [
+                "VdssStack",
+                "Outputs.InternalTierVIP"
+              ]
+           },
+           "extSelfIP": {
+            "Fn::GetAtt": [
+                "VdssStack",
+                "Outputs.extSelfIPInternalTier"
+              ]
+           },
+          "demoAppPoolMember": {
+            "Fn::GetAtt": [
+              "AppVpcStack",
+              "Outputs.demoAppPrivateIP"
+            ]
+          },
           "sshKey": {
             "Ref": "sshKey"
           },
+          "instanceType": {
+            "Ref": "instanceTypeInternalTier"
+           },
           "restrictedSrcAddress": "0.0.0.0/0",
           "declarationUrlrouting": {
             "Fn::Sub": "https://${pQuickstartS3BucketName}.s3.amazonaws.com/${pQuickstartS3KeyPrefix}/BIG-IP/atc/as3/mgmt_forwardingVIP.json"
-          }
+          },
+          "declarationUrldemoApp": {
+            "Fn::Sub": "https://${pQuickstartS3BucketName}.s3.amazonaws.com/${pQuickstartS3KeyPrefix}/BIG-IP/atc/as3/tier3/demoAppVIP-InternalTier.json"
+          },
+          "as3rpmUrl": {
+            "Fn::Sub": "http://raw.githubusercontent.com/F5Networks/f5-appsvcs-extension/master/dist/lts/3.13.2/f5-appsvcs-3.13.2-1.noarch.rpm"
+           },
+         "as3InstallFileUrl": {
+            "Fn::Sub": "https://${pQuickstartS3BucketName}.s3.amazonaws.com/${pQuickstartS3KeyPrefix}/BIG-IP/atc/as3/install-rpm.sh"
+           } 
         },
         "Tags": [
           {

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,6 +7,7 @@ phases:
   build:
     commands:
       # test and build f5_sca_libs
+       - yum install which -y
        - cd lambda/f5_sca_libs
        - make install 
        - pipenv run make test


### PR DESCRIPTION
BIG-IP config updates
- removed EIPs from Internal Tier
- now use predetermined static IP for VIP
- edited BIG-IP tmsh config to protect Demo App

Demo App and config updates
- added a Demo App in App VPC

Network and VPC updates
- added exports for pre-determined last octet IPs
- added input params in BIG-IP to use chosen IPs
- added network routes for BIG-IPs

AS3 updates
- BIG-IP now installs latest AS3 LTS 3.13.2
- prepared AS3 declarations for BIG-IPS
- AS3 declarations still require AFM and APM updates

Other
- removed unused goStandby script from BIG-IP cfn-init
- correct some terminology
- now calling Tiers External and Internal
- DependsOn in JumpHost now avoid rare AWS sequence issue